### PR TITLE
Changed import to xhtml2pdf instead of pisa.

### DIFF
--- a/enhanced_cbv/response.py
+++ b/enhanced_cbv/response.py
@@ -10,6 +10,11 @@ class PDFTemplateResponse(TemplateResponse):
 
     # The following is needed due to an error un pisa (pdf generation)
     # It must be executed once at startup
+    #
+    # TODO: Check if this still happends in xhtml2pdf (the most up-to-date
+    # version of pisa was renamed). Otherwise, report it to
+    # https://github.com/chrisglass/xhtml2pdf
+
     import logging
     class PisaNullHandler(logging.Handler):
         def emit(self, record):
@@ -31,7 +36,7 @@ class PDFTemplateResponse(TemplateResponse):
 
         # The following is required for PDF generation
 
-        import ho.pisa as pisa
+        import xhtml2pdf.pisa as pisa # The import is changed to xhtml2pdf
 
         if not self._is_rendered:
 


### PR DESCRIPTION
Hi there,

I am the current maintainer of pisa/xhtml2pdf.
I noticed you used an older version (ho.pisa), and quite a lot of stuff changed since that time. The code to generate PDFs is now slightly faster, and does generally look in a better shape.

I took the liberty to add comments to your code (that's awesome by the way, really handly) to reflect that.

Let me know if something doesn't work as intented or if you wish to have pull requests in another format... etc... :)

Thanks.
- Chris
