### PR TITLE
Consider views subdirectory as part of the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1.dev',
     author='Ivan Raskovsky (rasca)',
     author_email='raskovsky@gmail.com',
-    packages=['enhanced_cbv',],
+    packages=['enhanced_cbv','enhanced_cbv.views'],
     license='BSD',
     description='generic class based views with enhanced functionallity',
     long_description=open('README.txt').read(),


### PR DESCRIPTION
Explicitely tells that the 'views' subdirectory is part of the enhanced_cbv package and should be installed.

If you don't do so, the views directory will not be considered when using "pip install".
